### PR TITLE
Fixed bug in componentWillReceiveProps

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,8 @@ export default class Pusher extends Component {
   }
 
   unbindPusherEvent(channel, event) {
-    this._channel.unbind(event, this.props.onUpdate);
+    const _channel = Pusher.pusherClient.channels.find(channel);
+    _channel.unbind(event, this.props.onUpdate);
     Pusher.channels[channel]--;
 
     if (Pusher.channels[channel] <= 0) {


### PR DESCRIPTION
Currently on componentWillReceiveProps the logic would first bind to
the new channel/event and then unbind the old channel/event. This
introduces a bug because both the bind/unbind event use this._channel. I
have updated the unbind method to use a local variable and find the
channel again based on the argument and then continue it's logic. This
ensures that the on componentWillReceiveProps the events will be
subsribed to as expected.
